### PR TITLE
Improve logging around contact pairing

### DIFF
--- a/src/incomingMessageSinks/accounts/accountCreation.spec.ts
+++ b/src/incomingMessageSinks/accounts/accountCreation.spec.ts
@@ -13,6 +13,7 @@ describe('accountCreation handler', () => {
     await expect(
       accountCreation.handler(
         {
+          parcelId: 'parcel id',
           senderId: 'sender',
           recipientId: 'recipient',
           contentType: accountCreation.contentType,

--- a/src/incomingMessageSinks/accounts/accountLinking.spec.ts
+++ b/src/incomingMessageSinks/accounts/accountLinking.spec.ts
@@ -13,6 +13,7 @@ describe('accountLinking handler', () => {
     await expect(
       accountLinking.handler(
         {
+          parcelId: 'parcel id',
           senderId: 'sender',
           recipientId: 'recipient',
           contentType: accountLinking.contentType,

--- a/src/incomingMessageSinks/contactPairing/pairingRequestTmp.spec.ts
+++ b/src/incomingMessageSinks/contactPairing/pairingRequestTmp.spec.ts
@@ -8,28 +8,30 @@ import { ContactPairingRequest } from '../../models/ContactPairingRequest.model.
 import pairingRequestTmp, { MATCH_CONTENT_TYPE } from './pairingRequestTmp.js';
 
 function serialiseContactRequest(
-  requesterId: string,
-  targetId: string,
+  requesterVeraId: string,
+  targetVeraId: string,
   requesterIdKey: Buffer,
 ): Buffer {
-  return Buffer.from(`${requesterId},${targetId},${requesterIdKey.toString('base64')}`);
+  return Buffer.from(`${requesterVeraId},${targetVeraId},${requesterIdKey.toString('base64')}`);
 }
 
 function serialiseContactMatch(
-  requesterId: string,
-  targetId: string,
+  requesterVeraId: string,
+  targetVeraId: string,
   requesterEndpointId: string,
   requesterIdKey: Buffer,
 ): Buffer {
   return Buffer.from(
-    `${requesterId},${targetId},${requesterEndpointId},${requesterIdKey.toString('base64')}`,
+    `${requesterVeraId},${targetVeraId},${requesterEndpointId},${requesterIdKey.toString(
+      'base64',
+    )}`,
   );
 }
 
 describe('contactRequestTmp', () => {
-  const requesterId = 'requester@example.com';
+  const requesterVeraId = 'requester@example.com';
   const requesterIdKey = Buffer.from('requesterIdKey');
-  const targetId = 'target@foo.bar';
+  const targetVeraId = 'target@foo.bar';
   const targetIdKey = Buffer.from('targetIdKey');
 
   const {
@@ -58,42 +60,47 @@ describe('contactRequestTmp', () => {
 
   describe('Non-matching request', () => {
     test('Request should be created if it does not exist', async () => {
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey));
 
       await expect(
-        requestModel.exists({ requesterId, targetId, requesterEndpointId, requesterIdKey }),
+        requestModel.exists({ requesterVeraId, targetVeraId, requesterEndpointId, requesterIdKey }),
       ).resolves.not.toBeNull();
       expect(logs).toContainEqual(
         partialPinoLog('info', 'Contact request created or updated', {
-          requesterId,
-          targetId,
+          requesterVeraId,
+          targetVeraId,
         }),
       );
     });
 
     test('Request should be updated if it exists', async () => {
       // Request #1
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey));
 
       // Request #2
       const requesterIdKey2 = Buffer.concat([requesterIdKey, Buffer.from('2')]);
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey2));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey2));
 
       await expect(
-        requestModel.exists({ requesterId, targetId, requesterEndpointId, requesterIdKey }),
+        requestModel.exists({
+          requesterVeraId,
+          targetVeraId,
+          requesterEndpointId,
+          requesterIdKey,
+        }),
       ).resolves.toBeNull();
       await expect(
         requestModel.exists({
-          requesterId,
-          targetId,
+          requesterVeraId,
+          targetVeraId,
           requesterEndpointId,
           requesterIdKey: requesterIdKey2,
         }),
       ).resolves.not.toBeNull();
       expect(logs).toContainEqual(
         partialPinoLog('info', 'Contact request created or updated', {
-          requesterId,
-          targetId,
+          requesterVeraId,
+          targetVeraId,
         }),
       );
     });
@@ -102,26 +109,26 @@ describe('contactRequestTmp', () => {
   describe('Matching request', () => {
     test('Neither request should be left in the DB', async () => {
       // Request #1: Swap the requester and target
-      await runner(serialiseContactRequest(targetId, requesterId, targetIdKey));
+      await runner(serialiseContactRequest(targetVeraId, requesterVeraId, targetIdKey));
 
       // Request #2
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey));
 
-      await expect(requestModel.exists({ requesterId, targetId })).resolves.toBeNull();
+      await expect(requestModel.exists({ requesterVeraId, targetVeraId })).resolves.toBeNull();
       await expect(
-        requestModel.exists({ requesterId: targetId, targetId: requesterId }),
+        requestModel.exists({ requesterVeraId: targetVeraId, targetVeraId: requesterVeraId }),
       ).resolves.toBeNull();
     });
 
     test('Both peers should get their requests swapped', async () => {
       // Request #1: Swap the requester and target
       const originalRequesterEndpointId = 'originalRequesterEndpointId';
-      await runner(serialiseContactRequest(targetId, requesterId, targetIdKey), {
+      await runner(serialiseContactRequest(targetVeraId, requesterVeraId, targetIdKey), {
         senderEndpointId: originalRequesterEndpointId,
       });
 
       // Request #2
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey));
 
       expect(emittedEvents).toHaveLength(2);
       const [event1, event2] = emittedEvents;
@@ -133,8 +140,8 @@ describe('contactRequestTmp', () => {
 
           // eslint-disable-next-line @typescript-eslint/naming-convention,camelcase
           data_base64: serialiseContactMatch(
-            requesterId,
-            targetId,
+            requesterVeraId,
+            targetVeraId,
             requesterEndpointId,
             targetIdKey,
           ).toString('base64'),
@@ -148,8 +155,8 @@ describe('contactRequestTmp', () => {
 
           // eslint-disable-next-line @typescript-eslint/naming-convention,camelcase
           data_base64: serialiseContactMatch(
-            targetId,
-            requesterId,
+            targetVeraId,
+            requesterVeraId,
             originalRequesterEndpointId,
             requesterIdKey,
           ).toString('base64'),
@@ -159,15 +166,15 @@ describe('contactRequestTmp', () => {
 
     test('Match should be logged', async () => {
       // Request #1: Swap the requester and target
-      await runner(serialiseContactRequest(targetId, requesterId, targetIdKey));
+      await runner(serialiseContactRequest(targetVeraId, requesterVeraId, targetIdKey));
 
       // Request #2
-      await runner(serialiseContactRequest(requesterId, targetId, requesterIdKey));
+      await runner(serialiseContactRequest(requesterVeraId, targetVeraId, requesterIdKey));
 
       expect(logs).toContainEqual(
         partialPinoLog('info', 'Contact request matched', {
-          requesterId,
-          targetId,
+          requesterVeraId,
+          targetVeraId,
         }),
       );
     });

--- a/src/incomingMessageSinks/contactPairing/pairingRequestTmp.spec.ts
+++ b/src/incomingMessageSinks/contactPairing/pairingRequestTmp.spec.ts
@@ -147,6 +147,9 @@ describe('contactRequestTmp', () => {
           ).toString('base64'),
         }),
       );
+      expect(logs).toContainEqual(
+        partialPinoLog('debug', 'Pairing match sent', { peerId: requesterEndpointId }),
+      );
       expect(event2).toMatchObject(
         expect.objectContaining<Partial<CloudEventV1<Buffer>>>({
           source: ownEndpointId,
@@ -161,6 +164,9 @@ describe('contactRequestTmp', () => {
             requesterIdKey,
           ).toString('base64'),
         }),
+      );
+      expect(logs).toContainEqual(
+        partialPinoLog('debug', 'Pairing match sent', { peerId: originalRequesterEndpointId }),
       );
     });
 

--- a/src/incomingMessageSinks/contactPairing/pairingRequestTmp.ts
+++ b/src/incomingMessageSinks/contactPairing/pairingRequestTmp.ts
@@ -1,4 +1,5 @@
 import { getModelForClass, type ReturnModelType } from '@typegoose/typegoose';
+import type { BaseLogger } from 'pino';
 
 import type { MessageSink } from '../sinkTypes.js';
 import { ContactPairingRequest } from '../../models/ContactPairingRequest.model.js';
@@ -35,6 +36,7 @@ async function processMatch(
   ownEndpointId: string,
   emitter: Emitter<unknown>,
   requestModel: ReturnModelType<typeof ContactPairingRequest>,
+  logger: BaseLogger,
 ) {
   const matchMessage = makeOutgoingServiceMessage({
     senderId: ownEndpointId,
@@ -50,6 +52,7 @@ async function processMatch(
   });
   await emitter.emit(matchMessage);
   await requestModel.deleteOne({ requesterVeraId: requester.veraId, targetVeraId: target.veraId });
+  logger.debug({ peerId: requester.endpointId, parcelId: matchMessage.id }, 'Pairing match sent');
 }
 
 const pairingRequestTmp: MessageSink = {
@@ -93,6 +96,7 @@ const pairingRequestTmp: MessageSink = {
         message.recipientId,
         emitter,
         requestModel,
+        logger,
       );
 
       await processMatch(
@@ -104,6 +108,7 @@ const pairingRequestTmp: MessageSink = {
         message.recipientId,
         emitter,
         requestModel,
+        logger,
       );
 
       logger.info({ requesterVeraId, targetVeraId }, 'Contact request matched');

--- a/src/models/ContactPairingRequest.model.ts
+++ b/src/models/ContactPairingRequest.model.ts
@@ -4,7 +4,7 @@ import { secondsInDay } from 'date-fns';
 const TTL_DAYS = 90;
 const TTL_SECONDS = secondsInDay * TTL_DAYS;
 
-@index({ requesterId: 1, targetId: 1 }, { unique: true })
+@index({ requesterVeraId: 1, targetVeraId: 1 }, { unique: true })
 @modelOptions({ schemaOptions: { timestamps: { createdAt: 'creationDate', updatedAt: false } } })
 @index({ creationDate: 1 }, { expireAfterSeconds: TTL_SECONDS })
 export class ContactPairingRequest {
@@ -12,13 +12,13 @@ export class ContactPairingRequest {
    * The VeraId of the requester (e.g., `alice@example.com`).
    */
   @prop({ required: true })
-  public requesterId!: string;
+  public requesterVeraId!: string;
 
   /**
    * The VeraId of the target (e.g., `bob@example.com`).
    */
   @prop({ required: true })
-  public targetId!: string;
+  public targetVeraId!: string;
 
   /**
    * The requester's Awala endpoint id.

--- a/src/server/awalaServiceMessages.spec.ts
+++ b/src/server/awalaServiceMessages.spec.ts
@@ -66,7 +66,10 @@ describe('Awala service messages', () => {
     expect(response.statusCode).toBe(HTTP_STATUS_CODES.BAD_REQUEST);
     expect(response.json()).toHaveProperty('message', 'Unsupported service message content type');
     expect(logs).toContainEqual(
-      partialPinoLog('warn', 'Unsupported service message content type', { contentType }),
+      partialPinoLog('warn', 'Unsupported service message content type', {
+        contentType,
+        parcelId: EVENT.id,
+      }),
     );
   });
 
@@ -105,6 +108,7 @@ describe('Awala service messages', () => {
     await postEvent(EVENT, server);
 
     const expectedMessage: IncomingServiceMessage = {
+      parcelId: EVENT.id,
       senderId: EVENT.source,
       recipientId: EVENT.subject!,
       contentType: EVENT.datacontenttype!,

--- a/src/server/awalaServiceMessages.ts
+++ b/src/server/awalaServiceMessages.ts
@@ -54,12 +54,12 @@ export default function registerRoutes(
           .send({ message: 'Invalid incoming service message' });
       }
 
-      const contentType = event.datacontenttype!;
-      const eventAwareLogger = request.log.child({ contentType });
+      const parcelAwareLogger = request.log.child({ parcelId: message.parcelId });
 
+      const contentType = event.datacontenttype!;
       const handler = HANDLER_BY_TYPE[contentType] as MessageSinkHandler | undefined;
       if (handler === undefined) {
-        eventAwareLogger.warn('Unsupported service message content type');
+        parcelAwareLogger.warn({ contentType }, 'Unsupported service message content type');
         return reply
           .status(HTTP_STATUS_CODES.BAD_REQUEST)
           .send({ message: 'Unsupported service message content type' });
@@ -67,7 +67,7 @@ export default function registerRoutes(
 
       const context = {
         emitter,
-        logger: eventAwareLogger,
+        logger: parcelAwareLogger,
         dbConnection: fastify.mongoose,
       };
       const wasFulfilled = await handler(message, context);

--- a/src/testUtils/messageSinks.ts
+++ b/src/testUtils/messageSinks.ts
@@ -40,6 +40,7 @@ export function makeSinkTestRunner(sink: MessageSink): TestRunnerContext {
       await expect(
         sink.handler(
           {
+            parcelId: 'parcel id',
             senderId: options?.senderEndpointId ?? senderEndpointId,
             recipientId: recipientEndpointId,
             contentType: sink.contentType,

--- a/src/utilities/awalaEndpoint.spec.ts
+++ b/src/utilities/awalaEndpoint.spec.ts
@@ -31,6 +31,12 @@ describe('makeIncomingServiceMessage', () => {
     expect(message.senderId).toBe(event.source);
   });
 
+  test('Parcel id should be taken from event id', () => {
+    const message = makeIncomingServiceMessage(event);
+
+    expect(message.parcelId).toBe(event.id);
+  });
+
   describe('Recipient', () => {
     test('Should be taken from event subject', () => {
       const message = makeIncomingServiceMessage(event);

--- a/src/utilities/awalaEndpoint.ts
+++ b/src/utilities/awalaEndpoint.ts
@@ -22,7 +22,9 @@ export interface OutgoingServiceMessage extends ServiceMessage {
   readonly expiry?: Date;
 }
 
-export type IncomingServiceMessage = ServiceMessage;
+export interface IncomingServiceMessage extends ServiceMessage {
+  readonly parcelId: string;
+}
 
 export function makeIncomingServiceMessage(event: CloudEventV1<Buffer>): IncomingServiceMessage {
   if (event.type !== INCOMING_SERVICE_MESSAGE_TYPE) {
@@ -38,6 +40,7 @@ export function makeIncomingServiceMessage(event: CloudEventV1<Buffer>): Incomin
     throw new Error('Missing event data');
   }
   return {
+    parcelId: event.id,
     senderId: event.source,
     recipientId: event.subject,
     contentType: event.datacontenttype,


### PR DESCRIPTION
- Include `parcelId` in all logs.
- Log each pairing match that gets sent.